### PR TITLE
Inject configured message converters into RqueueEndpointManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ hs_err_pid*
 /.gradle/
 /build/
 /*/build/
+
+.DS_Store

--- a/rqueue-core/src/main/java/com/github/sonus21/rqueue/core/impl/RqueueEndpointManagerImpl.java
+++ b/rqueue-core/src/main/java/com/github/sonus21/rqueue/core/impl/RqueueEndpointManagerImpl.java
@@ -28,12 +28,18 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.util.CollectionUtils;
 
 public class RqueueEndpointManagerImpl extends BaseMessageSender implements RqueueEndpointManager {
 
   public RqueueEndpointManagerImpl(RqueueMessageTemplate messageTemplate) {
     super(messageTemplate);
+  }
+
+  public RqueueEndpointManagerImpl(RqueueMessageTemplate messageTemplate,
+      List<MessageConverter> messageConverters) {
+    super(messageTemplate, messageConverters);
   }
 
   @Override

--- a/rqueue-spring-boot-starter/src/main/java/com/github/sonus21/rqueue/spring/boot/RqueueListenerAutoConfig.java
+++ b/rqueue-spring-boot-starter/src/main/java/com/github/sonus21/rqueue/spring/boot/RqueueListenerAutoConfig.java
@@ -94,6 +94,10 @@ public class RqueueListenerAutoConfig extends RqueueListenerBaseConfig {
   @Bean
   @ConditionalOnMissingBean
   public RqueueEndpointManager rqueueEndpointManager(RqueueMessageTemplate rqueueMessageTemplate) {
+    if (simpleRqueueListenerContainerFactory.getMessageConverters() != null) {
+      return new RqueueEndpointManagerImpl(
+          rqueueMessageTemplate, simpleRqueueListenerContainerFactory.getMessageConverters());
+    }
     return new RqueueEndpointManagerImpl(rqueueMessageTemplate);
   }
 


### PR DESCRIPTION
At the moment the default initialization of `RqueueEndpointManager` ignores any custom defined `MessageConverters` and overrides them with the rqueue project defaults.

This change initializes the `RqueueEndpointManger` using the same pattern as the other classes that extend from `BaseMessageSender`.

With this change the `RqueueEndpointManager` uses the same MessageConverter as the other classes.