### PR TITLE
Explicit PathVariable name in queue related endpoints

### DIFF
--- a/rqueue-core/src/main/java/com/github/sonus21/rqueue/web/controller/ReactiveRqueueViewController.java
+++ b/rqueue-core/src/main/java/com/github/sonus21/rqueue/web/controller/ReactiveRqueueViewController.java
@@ -78,7 +78,7 @@ public class ReactiveRqueueViewController extends BaseReactiveController {
 
   @GetMapping("queues/{queueName}")
   public Mono<View> queueDetail(
-      @PathVariable String queueName,
+      @PathVariable("queueName") String queueName,
       Model model,
       ServerHttpRequest request,
       ServerHttpResponse response)

--- a/rqueue-core/src/main/java/com/github/sonus21/rqueue/web/controller/RqueueViewController.java
+++ b/rqueue-core/src/main/java/com/github/sonus21/rqueue/web/controller/RqueueViewController.java
@@ -77,7 +77,7 @@ public class RqueueViewController extends BaseController {
 
   @GetMapping("queues/{queueName}")
   public View queueDetail(
-      @PathVariable String queueName,
+      @PathVariable("queueName") String queueName,
       Model model,
       HttpServletRequest request,
       HttpServletResponse response)


### PR DESCRIPTION
# Description

Using this lib in an updated SpringBoot project works fine except for the exploration of the Queue details in the UI:


In order to prevent having to compile with parameter flag and needing to parse bytecode o deduce the path variable name on the queue related endpoints.

Fixes #218 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

NA


**Test Configuration**:
* Spring Version
* Spring Boot Version
* Redis Driver Version


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

