### PR TITLE
Update Pebble to fix CVE-2022-37767

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ ext {
 
     // server
     jakartaServletVersion = "6.0.0"
-    pebbleVersion = "3.2.0"
+    pebbleVersion = "3.2.2"
 
     // database
     lettuceVersion = "6.2.2.RELEASE"


### PR DESCRIPTION
# Description

CVE-2022-37767 has been around since June 2023 is is tracked in our vuln management tools as a 9.8 severity though this is a disputed report. It's a patch version so the chances of a regression are low and this will remediate a high severity issue.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

PR jobs should run the below to confirm it's still working

- [ ] Unit Test
- [ ] Integration Test


**Test Configuration**:
* Spring Version N/A
* Spring Boot Version N/A
* Redis Driver Version N/A


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

