### PR TITLE
CVE-2022-37767 - Upgrade Pebble from 3.2.0 to 3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ ext {
 
     // server
     jakartaServletVersion = "6.0.0"
-    pebbleVersion = "3.2.0"
+    pebbleVersion = "3.2.2"
 
     // database
     lettuceVersion = "6.2.2.RELEASE"


### PR DESCRIPTION
Pebble has been vulnerable for >1 year, this patch version fixes it

# Description

Pebble needs a patch upgrade to resolve a CVE. It's been active for a long time, for some reason dependabot doesn't seem to be updating it. Even if it's disputed, why remain out of date?

Fixes # (issue)

** DISPUTED ** Pebble Templates allows attackers to bypass a protection mechanism and implement arbitrary code execution with springbok. NOTE: the vendor disputes this because input to the Pebble templating engine is intended to include arbitrary Java code, and thus either the input should not arrive from an untrusted source, or else the application using the engine should apply restrictions to the input. The engine is not responsible for validating the input.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Automated PR tests only.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

