### PR TITLE
ci: compile main sources before generating Coveralls report

### DIFF
--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -62,6 +62,17 @@ jobs:
       - name: Compile test sources
         run: ./gradlew compileTestJava
 
+      - name: Upload compiled classes
+        uses: actions/upload-artifact@v4
+        with:
+          name: compiled-classes
+          path: |
+            **/build/classes/
+            **/build/generated/
+            **/build/resources/
+          if-no-files-found: error
+          retention-days: 1
+
   unit_test:
     needs: build
     runs-on: ubuntu-latest
@@ -85,6 +96,11 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+
+      - name: Download compiled classes
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-classes
 
       - name: Run unit tests
         run: ./gradlew test -DincludeTags=unit
@@ -138,6 +154,11 @@ jobs:
           sudo apt-get install -y redis-server
           redis-cli --version
 
+      - name: Download compiled classes
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-classes
+
       - name: Run producer-only tests
         run: ./gradlew test -DincludeTags=producerOnly
 
@@ -189,6 +210,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y redis-server
           redis-cli --version
+
+      - name: Download compiled classes
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-classes
 
       - name: Run integration tests
         run: ./gradlew test -DincludeTags=integration -DexcludeTags=redisCluster,producerOnly,local
@@ -260,6 +286,11 @@ jobs:
           sleep 30
           yes yes | redis-cli --cluster create 127.0.0.1:9000 127.0.0.1:9001 127.0.0.1:9002 127.0.0.1:9003 127.0.0.1:9004 127.0.0.1:9005 --cluster-replicas 1
 
+      - name: Download compiled classes
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-classes
+
       - name: Run Redis cluster tests
         run: ./gradlew test -DincludeTags=redisCluster
 
@@ -313,6 +344,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y redis-server
           redis-cli --version
+
+      - name: Download compiled classes
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-classes
 
       - name: Run reactive integration tests
         run: ./gradlew test -DincludeTags=integration -DexcludeTags=redisCluster,producerOnly,local
@@ -382,6 +418,11 @@ jobs:
             sleep 1
           done
 
+      - name: Download compiled classes
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-classes
+
       - name: Run NATS tests
         env:
           NATS_RUNNING: "true"
@@ -445,8 +486,10 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Compile main sources
-        run: ./gradlew compileJava
+      - name: Download compiled classes
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-classes
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -62,17 +62,6 @@ jobs:
       - name: Compile test sources
         run: ./gradlew compileTestJava
 
-      - name: Upload compiled classes
-        uses: actions/upload-artifact@v4
-        with:
-          name: compiled-classes
-          path: |
-            **/build/classes/
-            **/build/generated/
-            **/build/resources/
-          if-no-files-found: error
-          retention-days: 1
-
   unit_test:
     needs: build
     runs-on: ubuntu-latest
@@ -96,11 +85,6 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-
-      - name: Download compiled classes
-        uses: actions/download-artifact@v4
-        with:
-          name: compiled-classes
 
       - name: Run unit tests
         run: ./gradlew test -DincludeTags=unit
@@ -154,11 +138,6 @@ jobs:
           sudo apt-get install -y redis-server
           redis-cli --version
 
-      - name: Download compiled classes
-        uses: actions/download-artifact@v4
-        with:
-          name: compiled-classes
-
       - name: Run producer-only tests
         run: ./gradlew test -DincludeTags=producerOnly
 
@@ -210,11 +189,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y redis-server
           redis-cli --version
-
-      - name: Download compiled classes
-        uses: actions/download-artifact@v4
-        with:
-          name: compiled-classes
 
       - name: Run integration tests
         run: ./gradlew test -DincludeTags=integration -DexcludeTags=redisCluster,producerOnly,local
@@ -286,11 +260,6 @@ jobs:
           sleep 30
           yes yes | redis-cli --cluster create 127.0.0.1:9000 127.0.0.1:9001 127.0.0.1:9002 127.0.0.1:9003 127.0.0.1:9004 127.0.0.1:9005 --cluster-replicas 1
 
-      - name: Download compiled classes
-        uses: actions/download-artifact@v4
-        with:
-          name: compiled-classes
-
       - name: Run Redis cluster tests
         run: ./gradlew test -DincludeTags=redisCluster
 
@@ -344,11 +313,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y redis-server
           redis-cli --version
-
-      - name: Download compiled classes
-        uses: actions/download-artifact@v4
-        with:
-          name: compiled-classes
 
       - name: Run reactive integration tests
         run: ./gradlew test -DincludeTags=integration -DexcludeTags=redisCluster,producerOnly,local
@@ -418,11 +382,6 @@ jobs:
             sleep 1
           done
 
-      - name: Download compiled classes
-        uses: actions/download-artifact@v4
-        with:
-          name: compiled-classes
-
       - name: Run NATS tests
         env:
           NATS_RUNNING: "true"
@@ -486,10 +445,8 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Download compiled classes
-        uses: actions/download-artifact@v4
-        with:
-          name: compiled-classes
+      - name: Compile main sources
+        run: ./gradlew compileJava
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -445,6 +445,9 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Compile main sources
+        run: ./gradlew compileJava
+
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

The `coverage_report` job was silently failing to upload to Coveralls.

## Root cause

The job downloaded `.exec` artifacts and ran `coverageReportOnly`, but never compiled the main sources. JaCoCo's report generator silently skipped every package because `<module>/build/classes/java/main/` did not exist. Result: the merged `jacocoTestReport.xml` contained only `<sessioninfo>` entries (~3.4KB) instead of full coverage data (~1.1MB locally).

The `coverallsJacoco` plugin then short-circuited via `CoverallsReporter.kt:48`:

```kotlin
if (sourceFiles.count() == 0) {
    logger.info("source file set empty, skipping")
    return
}
```

— which returns 0, so the workflow step shows "success" while no upload happens.

## Fix

Add `./gradlew compileJava` to the `coverage_report` job before downloading artifacts and running `coverageReportOnly`.

## Verification

Downloaded the `coverage-report` artifact from a recent run (sha 6660aba) and confirmed the XML had no `<package>` elements. Locally, after running tests, the same XML has 244 source files with full coverage data and uploads successfully (verified with the production token).